### PR TITLE
libstagefright: Add support for NV21 color format

### DIFF
--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -133,6 +133,14 @@ LOCAL_SHARED_LIBRARIES += \
         libdl \
         libRScpp \
 
+ifeq ($(BOARD_USE_SAMSUNG_CAMERAFORMAT_NV21), true)
+# This needs flag requires the following string constant in
+# CameraParametersExtra.h:
+#
+# const char CameraParameters::PIXEL_FORMAT_YUV420SP_NV21[] = "nv21";
+LOCAL_CFLAGS += -DUSE_SAMSUNG_CAMERAFORMAT_NV21
+endif
+
 LOCAL_CFLAGS += -Wno-multichar -Werror -Wno-error=deprecated-declarations -Wall
 
 LOCAL_C_INCLUDES += $(call project-path-for,qcom-media)/mm-core/inc

--- a/media/libstagefright/CameraSource.cpp
+++ b/media/libstagefright/CameraSource.cpp
@@ -135,6 +135,13 @@ static int32_t getColorFormat(const char* colorFormat) {
 #endif
     }
 
+#ifdef USE_SAMSUNG_CAMERAFORMAT_NV21
+    if (!strcmp(colorFormat, CameraParameters::PIXEL_FORMAT_YUV420SP_NV21)) {
+        static const int OMX_SEC_COLOR_FormatNV21Linear = 0x7F000011;
+        return OMX_SEC_COLOR_FormatNV21Linear;
+    }
+#endif /* USE_SAMSUNG_CAMERAFORMAT_NV21 */
+
     if (!strcmp(colorFormat, CameraParameters::PIXEL_FORMAT_YUV422I)) {
         return OMX_COLOR_FormatYCbYCr;
     }


### PR DESCRIPTION
This adds the native color format 'OMX_SEC_COLOR_FormatNV21Linear' of
exynos5 which is NV21 and needed for the camera. You can turn it on
with:

BOARD_USE_SAMSUNG_COLORFORMAT_NV21 := true

It requires

const char CameraParameters::PIXEL_FORMAT_YUV420SP_NV21[] = "nv21";

to be specified in CameraExtraParameters.h.

Change-Id: I64ca86d074468b1e7a2958a73c3c0380e64a9fc0
Signed-off-by: Andreas Schneider <asn@cryptomilk.org>