### PR TITLE
stagefright: omx: Don't signal dataspace change on legacy QCOM

### DIFF
--- a/media/libstagefright/omx/GraphicBufferSource.cpp
+++ b/media/libstagefright/omx/GraphicBufferSource.cpp
@@ -564,6 +564,7 @@ void GraphicBufferSource::onDataSpaceChanged_l(
                 aspects.mTransfer, asString(aspects.mTransfer),
                 err, asString(err));
 
+#ifndef QCOM_BSP_LEGACY
         // signal client that the dataspace has changed; this will update the output format
         // TODO: we should tie this to an output buffer somehow, and signal the change
         // just before the output buffer is returned to the client, but there are many
@@ -573,6 +574,7 @@ void GraphicBufferSource::onDataSpaceChanged_l(
                 OMX_EventDataSpaceChanged, dataSpace,
                 (aspects.mRange << 24) | (aspects.mPrimaries << 16)
                         | (aspects.mMatrixCoeffs << 8) | aspects.mTransfer);
+#endif
     }
 }
 


### PR DESCRIPTION
This isn't supported in legacy media HAL, and causes things like
screen recording to fail when setting up the encoder.

Change-Id: Icb3f7b7dfefcfd72939037241568f28c01fc11ed